### PR TITLE
Remove the eprintln! calls from the decoder

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -81,11 +81,8 @@ impl SlipDecoder {
     /// of the source data was reached.
     ///
     pub fn decode(&mut self, source: &mut dyn Read, sink: &mut dyn Write) -> self::SlipResult {
-        eprintln!("{}:{}", file!(), line!());
         for value in source.bytes() {
             let value = value?;
-
-            eprintln!("{}:{} value => {:02X}", file!(), line!(), value);
 
             match self.state {
                 State::Normal => match value {


### PR DESCRIPTION
Thank you for your work on this crate!

We as using this in [espflash](https://github.com/esp-rs/espflash) and unfortunately the `eprintln!` calls in the decoder are interfering with our progress bar, so I have removed them.

Closes #6.