### PR TITLE
Derive debug for public types

### DIFF
--- a/src/aio/codec.rs
+++ b/src/aio/codec.rs
@@ -3,6 +3,7 @@ use crate::{SlipError, MAX_PACKET_SIZE};
 use bytes::{Bytes, BytesMut};
 use asynchronous_codec::{Decoder, Encoder};
 
+#[derive(Debug)]
 pub struct SlipCodec {
     decoder: SlipDecoder,
     encoder: SlipEncoder,

--- a/src/aio/decoder.rs
+++ b/src/aio/decoder.rs
@@ -3,6 +3,7 @@ use bytes::{Buf, BufMut, BytesMut};
 use asynchronous_codec::Decoder;
 
 /// SLIP decoding context
+#[derive(Debug)]
 pub struct SlipDecoder {
     buf: BytesMut,
     capacity: usize,

--- a/src/aio/encoder.rs
+++ b/src/aio/encoder.rs
@@ -2,6 +2,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 use asynchronous_codec::Encoder;
 
 /// SLIP encoder context
+#[derive(Debug)]
 pub struct SlipEncoder {
     inner: crate::SlipEncoder,
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -35,6 +35,7 @@ impl From<std::io::Error> for SlipError {
 
 pub type SlipResult = std::result::Result<usize, self::SlipError>;
 
+#[derive(Debug)]
 enum State {
     Normal,
     Error,
@@ -42,6 +43,7 @@ enum State {
 }
 
 /// SLIP decoder context
+#[derive(Debug)]
 pub struct SlipDecoder {
     count: usize,
     state: State,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,6 +1,7 @@
 use crate::{END, ESC, ESC_END, ESC_ESC};
 
 /// SLIP encoder context
+#[derive(Debug)]
 pub struct SlipEncoder {
     begin_with_end: bool,
 }

--- a/src/tokio/codec.rs
+++ b/src/tokio/codec.rs
@@ -3,6 +3,7 @@ use crate::{SlipError, MAX_PACKET_SIZE};
 use bytes::{Bytes, BytesMut};
 use tokio_util::codec::{Decoder, Encoder};
 
+#[derive(Debug)]
 pub struct SlipCodec {
     decoder: SlipDecoder,
     encoder: SlipEncoder,

--- a/src/tokio/decoder.rs
+++ b/src/tokio/decoder.rs
@@ -3,6 +3,7 @@ use bytes::{Buf, BufMut, BytesMut};
 use tokio_util::codec::Decoder;
 
 /// SLIP decoding context
+#[derive(Debug)]
 pub struct SlipDecoder {
     buf: BytesMut,
     capacity: usize,

--- a/src/tokio/encoder.rs
+++ b/src/tokio/encoder.rs
@@ -2,6 +2,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 use tokio_util::codec::Encoder;
 
 /// SLIP encoder context
+#[derive(Debug)]
 pub struct SlipEncoder {
     inner: crate::SlipEncoder,
 }


### PR DESCRIPTION
According to [The API Guidelines](https://rust-lang.github.io/api-guidelines/debuggability.html), it is desirable to implement `std::fmt::Debug` for public types.

This PR sprinkles `#[derive(Debug)]` where applicable.