### PR TITLE
slip-codec 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 license = "MIT"
 name = "slip-codec"
 repository = "https://github.com/jmaygarden/slip-codec"
-version = "0.3.4"
+version = "0.4.0"
 
 [features]
 default = []
@@ -13,7 +13,7 @@ async-codec = ["asynchronous-codec", "bytes"]
 tokio-codec = ["bytes", "tokio-util"]
 
 [dependencies]
-asynchronous-codec = { version = "0.6", optional = true }
+asynchronous-codec = { version = "0.7", optional = true }
 bytes = { version = "1", optional = true }
 tokio-util = { version = "0.7", features = ["codec"], optional = true }
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,24 @@
-# slip-codec
+slip-codec — SLIP Encoder/Decoder
+=================================
 
-SLIP encoder/decoder with Rust std::io::{Read, Write} interfaces.
+[![crates.io][crates-badge]][crates-url]
+[![docs.rs][docs-badge]][docs-url]
+[![MIT licensed][mit-badge]][mit-url]
+
+SLIP encoder/decoder with Rust [std::io](https://doc.rust-lang.org/std/io/index.html)::{[Read](https://doc.rust-lang.org/std/io/trait.Read.html), [Write](https://doc.rust-lang.org/std/io/trait.Write.html)} interfaces.
 
 Pure Rust implementation of [RFC 1055](https://tools.ietf.org/html/rfc1055) Serial Line Internet Protocol (SLIP). Test cases are lifted from the [serial_line_ip](https://crates.io/crates/serial-line-ip) crate that serves the same role, but uses slices for data handling.
+
+## Optional features
+
+Asynchronous interfaces are optionally provided in addition to the default synchronous interface.
+
+* **`async-codec`** — Implements runtime agnostic [asynchronous_codec](https://crates.io/crates/asynchronous-codec) traits
+* **`tokio-codec`** — Implements [tokio](https://tokio.rs) runtime [tokio_util::codec](https://docs.rs/tokio-util/latest/tokio_util/codec/index.html) traits
+
+[crates-badge]: https://img.shields.io/crates/v/slip-codec.svg
+[crates-url]: https://crates.io/crates/slip-codec
+[docs-badge]: https://docs.rs/slip-codec/badge.svg
+[docs-url]: https://docs.rs/slip-codec
+[mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
+[mit-url]: LICENSE

--- a/src/aio/codec.rs
+++ b/src/aio/codec.rs
@@ -40,10 +40,10 @@ impl Decoder for SlipCodec {
 }
 
 impl Encoder for SlipCodec {
-    type Item = Bytes;
+    type Item<'a> = Bytes;
     type Error = SlipError;
 
-    fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
+    fn encode(&mut self, item: Self::Item<'_>, dst: &mut BytesMut) -> Result<(), Self::Error> {
         self.encoder.encode(item, dst).map_err(SlipError::ReadError)
     }
 }

--- a/src/aio/encoder.rs
+++ b/src/aio/encoder.rs
@@ -17,10 +17,10 @@ impl SlipEncoder {
 }
 
 impl Encoder for SlipEncoder {
-    type Item = Bytes;
+    type Item<'a> = Bytes;
     type Error = std::io::Error;
 
-    fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
+    fn encode(&mut self, item: Self::Item<'_>, dst: &mut BytesMut) -> Result<(), Self::Error> {
         self.inner
             .encode(item.as_ref(), &mut dst.writer())
             .map(|_| ())

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -216,4 +216,32 @@ mod tests {
             assert_eq!(&DATA, buf.as_slice());
         }
     }
+
+    #[test]
+    fn compound_decode() {
+        const INPUT: [u8; 13] = [
+            0xc0, 0x01, 0x02, 0x03, 0x04, 0x05, 0xc0, 0x05, 0x06, 0x07, 0x08, 0x09, 0xc0,
+        ];
+        const DATA_1: [u8; 5] = [0x01, 0x02, 0x03, 0x04, 0x05];
+        const DATA_2: [u8; 5] = [0x05, 0x06, 0x07, 0x08, 0x09];
+
+        let mut slip = SlipDecoder::new();
+        let reader: &mut dyn std::io::Read = &mut INPUT.as_ref();
+
+        {
+            let mut buf: Vec<u8> = Vec::new();
+            let len = slip.decode(reader, &mut buf).unwrap();
+            assert_eq!(DATA_1.len(), len);
+            assert_eq!(DATA_1.len(), buf.len());
+            assert_eq!(&DATA_1, buf.as_slice());
+        }
+
+        {
+            let mut buf: Vec<u8> = Vec::new();
+            let len = slip.decode(reader, &mut buf).unwrap();
+            assert_eq!(DATA_2.len(), len);
+            assert_eq!(DATA_2.len(), buf.len());
+            assert_eq!(&DATA_2, buf.as_slice());
+        }
+    }
 }

--- a/src/tokio/codec.rs
+++ b/src/tokio/codec.rs
@@ -31,10 +31,10 @@ impl SlipCodec {
 }
 
 impl Decoder for SlipCodec {
-    type Item = BytesMut;
+    type Item = Bytes;
     type Error = SlipError;
 
-    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<BytesMut>, Self::Error> {
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         self.decoder.decode(src)
     }
 }

--- a/src/tokio/decoder.rs
+++ b/src/tokio/decoder.rs
@@ -1,5 +1,5 @@
 use crate::{SlipError, MAX_PACKET_SIZE};
-use bytes::{Buf, BufMut, BytesMut};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 use tokio_util::codec::Decoder;
 
 /// SLIP decoding context
@@ -22,7 +22,7 @@ impl SlipDecoder {
 }
 
 impl Decoder for SlipDecoder {
-    type Item = BytesMut;
+    type Item = Bytes;
     type Error = SlipError;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
@@ -33,7 +33,7 @@ impl Decoder for SlipDecoder {
         };
 
         match self.inner.decode(src, dst) {
-            Ok(len) => Ok(Some(self.buf.split_to(len))),
+            Ok(len) => Ok(Some(self.buf.split_to(len).freeze())),
             Err(SlipError::EndOfStream) => Ok(None),
             Err(e) => Err(e),
         }


### PR DESCRIPTION
- Update README
- Add a new unit test for decoding multiple messages with a single delimiter
- Change the tokio interfaces to use `Bytes` instead of `BytesMut`
- Update to `asynchronous-codec` 0.7